### PR TITLE
[ENH] only use the participants file

### DIFF
--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -55,7 +55,6 @@ jobs:
         -   name: install datasets
             run: |
                 cohort_creator install \
-                    -d inputs/datasets.tsv \
                     -p inputs/participants.tsv \
                     -o outputs \
                     --dataset_types raw mriqc fmriprep \
@@ -63,7 +62,6 @@ jobs:
         -   name: get data
             run: |
                 cohort_creator get \
-                    -d inputs/datasets.tsv \
                     -p inputs/participants.tsv \
                     -o outputs \
                     --dataset_types raw mriqc fmriprep \
@@ -74,7 +72,6 @@ jobs:
         -   name: copy data
             run: |
                 cohort_creator copy \
-                    -d inputs/datasets.tsv \
                     -p inputs/participants.tsv \
                     -o outputs \
                     --dataset_types raw mriqc fmriprep \

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,11 @@ clean:
 
 demo_anat:
 	cohort_creator install \
-		-d inputs/datasets.tsv \
 		-p inputs/participants.tsv \
 		-o outputs \
 		--dataset_types raw mriqc fmriprep \
 		--verbosity 2
 	cohort_creator get \
-		-d inputs/datasets.tsv \
 		-p inputs/participants.tsv \
 		-o outputs \
 		--dataset_types raw mriqc fmriprep \
@@ -41,7 +39,6 @@ demo_anat:
 		--jobs 6 \
 		--verbosity 2
 	cohort_creator copy \
-		-d inputs/datasets.tsv \
 		-p inputs/participants.tsv \
 		-o outputs \
 		--dataset_types raw mriqc fmriprep \
@@ -50,13 +47,11 @@ demo_anat:
 
 demo_func:
 	cohort_creator install \
-		-d inputs/datasets.tsv \
 		-p inputs/participants.tsv \
 		-o outputs \
 		--dataset_types raw mriqc fmriprep \
 		--verbosity 3
 	cohort_creator get \
-		-d inputs/datasets.tsv \
 		-p inputs/participants.tsv \
 		-o outputs \
 		--dataset_types raw mriqc fmriprep \
@@ -64,7 +59,6 @@ demo_func:
 		--jobs 6 \
 		--verbosity 3
 	cohort_creator copy \
-		-d inputs/datasets.tsv \
 		-p inputs/participants.tsv \
 		-o outputs \
 		--dataset_types raw mriqc fmriprep \
@@ -73,13 +67,11 @@ demo_func:
 
 demo_all:
 	cohort_creator install \
-		-d inputs/datasets.tsv \
 		-p inputs/participants.tsv \
 		-o outputs \
 		--dataset_types raw mriqc fmriprep \
 		--verbosity 3
 	cohort_creator get \
-		-d inputs/datasets.tsv \
 		-p inputs/participants.tsv \
 		-o outputs \
 		--dataset_types raw mriqc fmriprep \
@@ -88,7 +80,6 @@ demo_all:
 		--jobs 6 \
 		--verbosity 3
 	cohort_creator copy \
-		-d inputs/datasets.tsv \
 		-p inputs/participants.tsv \
 		-o outputs \
 		--dataset_types raw mriqc fmriprep \

--- a/README.md
+++ b/README.md
@@ -13,11 +13,10 @@
 Install a set of datalad datasets from openneuro and get the data for a set of participants.
 Then copy the data to a new directory structure to create a "cohort".
 
-Takes 2 files as input that should list:
-- source datasets
+Takes 1 file as input that should list:
 - subject in each dataset to be included in the cohort
 
-For examples of 2 inputs TSV files see this [page](https://github.com/neurobagel/documentation/wiki/Query-Tool#example-data)
+For examples of of inputs TSV files see this [page](https://github.com/neurobagel/documentation/wiki/Query-Tool#example-data)
 
 ## Requirements
 
@@ -54,6 +53,8 @@ pip install .
 
 ## Limitations
 
+Cohorts can only be created by aggregating data from openneuro and openneuro derivatives.
+
 ### Latest datasets
 
 Currently this should allow you to access:
@@ -74,7 +75,7 @@ Number of datasets: 863 with 37441 subjects including:
 
 It may be that very recent datasets are not available yet.
 
-### Datatypes, suffixes, Freesurfer
+### Datatypes, suffixes
 
 Only `anat` | `T1w` and `func` | `bold` data is supported at the moment.
 
@@ -100,21 +101,18 @@ run the following command from within the cohort_creator folder:
 
 ```bash
 cohort_creator install \
-  --datasets_listing inputs/datasets_with_mriqc.tsv \
   --participants_listing inputs/participants_with_mriqc.tsv \
   --output_dir outputs \
   --dataset_types raw mriqc \
   --verbosity 3
 
 cohort_creator get \
-  --datasets_listing inputs/datasets_with_mriqc.tsv \
   --participants_listing inputs/participants_with_mriqc.tsv \
   --output_dir outputs \
   --dataset_types raw mriqc \
   --verbosity 3
 
 cohort_creator copy \
-  --datasets_listing inputs/datasets_with_mriqc.tsv \
   --participants_listing inputs/participants_with_mriqc.tsv \
   --output_dir outputs \
   --dataset_types raw mriqc \

--- a/cohort_creator/_cli.py
+++ b/cohort_creator/_cli.py
@@ -40,7 +40,6 @@ def cli(argv: Sequence[str] = sys.argv) -> None:
 
     args, unknowns = parser.parse_known_args(argv[1:])
 
-    datasets_listing = Path(args.datasets_listing[0]).resolve()
     participants_listing = Path(args.participants_listing[0]).resolve()
     output_dir = Path(args.output_dir[0]).resolve()
 
@@ -53,7 +52,6 @@ def cli(argv: Sequence[str] = sys.argv) -> None:
     participants = check_tsv_content(participants_listing)
     check_participant_listing(participants)
 
-    datasets = check_tsv_content(datasets_listing)  # not needed for now
     datasets_to_install = list(participants["DatasetName"].unique())
 
     sourcedata_dir = output_dir / "sourcedata"
@@ -75,7 +73,6 @@ def cli(argv: Sequence[str] = sys.argv) -> None:
         if isinstance(jobs, list):
             jobs = jobs[0]
         get_data(
-            datasets=datasets,
             sourcedata=sourcedata_dir,
             participants=participants,
             dataset_types=dataset_types,
@@ -87,7 +84,6 @@ def cli(argv: Sequence[str] = sys.argv) -> None:
 
     if args.command == "copy":
         construct_cohort(
-            datasets=datasets,
             output_dir=output_dir,
             sourcedata_dir=sourcedata_dir,
             participants=participants,

--- a/cohort_creator/_parsers.py
+++ b/cohort_creator/_parsers.py
@@ -34,14 +34,6 @@ def base_parser() -> MuhParser:
 
 def add_common_arguments(parser: MuhParser) -> MuhParser:
     parser.add_argument(
-        "-d",
-        "--datasets_listing",
-        help="""
-        Path to TSV file containing the list of datasets to install.
-        """,
-        nargs=1,
-    )
-    parser.add_argument(
         "-p",
         "--participants_listing",
         help="""
@@ -83,14 +75,6 @@ def add_common_arguments(parser: MuhParser) -> MuhParser:
         type=int,
         nargs=1,
     )
-    # parser.add_argument(
-    #     "--dry_run",
-    #     help="""
-    #     Foo Bar
-    #     """,
-    #     action="store_true",
-    #     default=False,
-    # )
     return parser
 
 
@@ -140,7 +124,6 @@ def global_parser() -> MuhParser:
         .. code-block:: bash
 
             cohort_creator install \\
-                --datasets_listing inputs/datasets.tsv \\
                 --participants_listing inputs/participants.tsv \\
                 --output_dir outputs \\
                 --dataset_types raw mriqc fmriprep \\
@@ -159,7 +142,6 @@ def global_parser() -> MuhParser:
         .. code-block:: bash
 
             cohort_creator get \\
-                --datasets_listing inputs/datasets.tsv \\
                 --participants_listing inputs/participants.tsv \\
                 --output_dir outputs \\
                 --dataset_types raw mriqc fmriprep \\
@@ -191,7 +173,6 @@ def global_parser() -> MuhParser:
         .. code-block:: bash
 
             cohort_creator copy \\
-                --datasets_listing inputs/datasets.tsv \\
                 --participants_listing inputs/participants.tsv \\
                 --output_dir outputs \\
                 --dataset_types raw mriqc fmriprep \\

--- a/cohort_creator/_utils.py
+++ b/cohort_creator/_utils.py
@@ -210,7 +210,7 @@ def validate_dataset_types(dataset_types: list[str]) -> None:
             )
 
 
-def add_study_tsv(output_dir: Path, datasets: pd.DataFrame) -> None:
+def add_study_tsv(output_dir: Path, datasets: list[str]) -> None:
     """Create a study.tsv file."""
     cc_log.info(" creating study.tsv file")
     studies: dict[str, list[Any]] = {
@@ -221,7 +221,7 @@ def add_study_tsv(output_dir: Path, datasets: pd.DataFrame) -> None:
         "InstitutionAddress": [],
     }
 
-    for dataset_ in datasets["DatasetName"]:
+    for dataset_ in datasets:
         studies["study_ID"].append(dataset_)
 
         participants_tsv = dataset_path(output_dir, f"study-{dataset_}") / "participants.tsv"

--- a/cohort_creator/cohort_creator.py
+++ b/cohort_creator/cohort_creator.py
@@ -387,7 +387,7 @@ def _recreate_mriqc_group_reports(
                 cc_log.error(f"  failed to pull docker image: {username}/mriqc:{version}")
                 continue
 
-            cmd = f"docker run -it --rm \
+            cmd = f"docker run -t --rm \
                     -v {target_pth}:/bids_dir \
                     -v {mriqc}:/output_dir \
                         {username}/mriqc:{version} /bids_dir /output_dir group"

--- a/cohort_creator/cohort_creator.py
+++ b/cohort_creator/cohort_creator.py
@@ -83,7 +83,6 @@ def _install(dataset_name: str, dataset_types: list[str], output_path: Path) -> 
 
 
 def get_data(
-    datasets: pd.DataFrame,
     sourcedata: Path,
     participants: pd.DataFrame,
     dataset_types: list[str],
@@ -96,8 +95,6 @@ def get_data(
 
     Parameters
     ----------
-    datasets : pd.DataFrame
-
     sourcedata : Path
 
     participants : pd.DataFrame
@@ -120,7 +117,9 @@ def get_data(
     if isinstance(datatypes, str):
         datatypes = [datatypes]
 
-    for dataset_ in datasets["DatasetName"]:
+    datasets = sorted(participants["DatasetName"].unique().tolist())
+
+    for dataset_ in datasets:
         cc_log.info(f" {dataset_}")
 
         participants_ids = get_participant_ids(participants, dataset_)
@@ -188,7 +187,6 @@ def _get_data_this_subject(
 
 
 def construct_cohort(
-    datasets: pd.DataFrame,
     output_dir: Path,
     sourcedata_dir: Path,
     participants: pd.DataFrame,
@@ -200,8 +198,6 @@ def construct_cohort(
 
     Parameters
     ----------
-    datasets : pd.DataFrame
-
     output_dir : Path
 
     sourcedata_dir : Path
@@ -225,7 +221,9 @@ def construct_cohort(
     with open(output_dir / "README.md", "w") as f:
         f.write("# README\n\n")
 
-    for dataset_ in datasets["DatasetName"]:
+    datasets = sorted(participants["DatasetName"].unique().tolist())
+
+    for dataset_ in datasets:
         cc_log.info(f" {dataset_}")
 
         participants_ids = get_participant_ids(participants, dataset_)
@@ -316,13 +314,13 @@ def _copy_this_subject(
 
 
 def _generate_bagel_for_cohort(
-    output_dir: Path, sourcedata_dir: Path, datasets: pd.DataFrame, dataset_types: list[str]
+    output_dir: Path, sourcedata_dir: Path, datasets: list[str], dataset_types: list[str]
 ) -> None:
     """Track what subjects have been processed by what pipeline."""
     cc_log.info(" creating bagel.csv file")
     bagel = _new_bagel()
     supported_dataset_types = ["fmriprep", "mriqc"]
-    for dataset_type_, dataset_ in itertools.product(dataset_types, datasets["DatasetName"]):
+    for dataset_type_, dataset_ in itertools.product(dataset_types, datasets):
         if dataset_type_ not in supported_dataset_types:
             continue
         cc_log.info(f"  {dataset_} - {dataset_type_}")
@@ -347,7 +345,7 @@ https://dash.neurobagel.org/
 
 
 def _recreate_mriqc_group_reports(
-    output_dir: Path, datasets: pd.DataFrame, dataset_types: list[str]
+    output_dir: Path, datasets: list[str], dataset_types: list[str]
 ) -> None:
     """Recreate MRIQC group reports."""
     log_folder = output_dir / "logs"
@@ -361,7 +359,7 @@ def _recreate_mriqc_group_reports(
     if "mriqc" not in dataset_types:
         return None
 
-    for dataset_ in datasets["DatasetName"]:
+    for dataset_ in datasets:
         cc_log.info(f" {dataset_}")
 
         target_pth = return_target_pth(output_dir=output_dir, dataset_type="raw", dataset=dataset_)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,8 +3,8 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
-SPHINXPROJ    = bidsmreye
+SPHINXBUILD   = python -m sphinx
+SPHINXPROJ    = cohort_creator
 SOURCEDIR     = source
 BUILDDIR      = _build
 

--- a/docs/source/cohort_creator.rst
+++ b/docs/source/cohort_creator.rst
@@ -4,6 +4,14 @@ cohort\_creator package
 Submodules
 ----------
 
+cohort\_creator.bagelify module
+-------------------------------
+
+.. automodule:: cohort_creator.bagelify
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cohort\_creator.cohort\_creator module
 --------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,7 @@ author = "Rémi Gau"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.coverage",
     "sphinx_copybutton",
     "myst_parser",
     "sphinxarg.ext",
@@ -37,3 +38,7 @@ templates_path = ["_templates"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "furo"
+
+
+# Configuration of sphinx.ext.coverage
+coverage_show_missing_items = True

--- a/tests/test_cohort_creator.py
+++ b/tests/test_cohort_creator.py
@@ -26,7 +26,6 @@ def test_install_datasets(tmp_path, caplog):
 
 
 def test_construct_cohort(tmp_path):
-    datasets = pd.DataFrame({"DatasetName": ["ds000001"]})
     participants = pd.DataFrame(
         {"DatasetName": ["ds000001"], "SubjectID": ["sub-01"], "SessionID": [""]}
     )
@@ -38,7 +37,6 @@ def test_construct_cohort(tmp_path):
         datasets=["ds000001", "foo"], sourcedata=sourcedata, dataset_types=dataset_types
     )
     get_data(
-        datasets=datasets,
         sourcedata=sourcedata,
         participants=participants,
         dataset_types=dataset_types,
@@ -47,7 +45,6 @@ def test_construct_cohort(tmp_path):
         jobs=2,
     )
     get_data(
-        datasets=datasets,
         sourcedata=sourcedata,
         participants=participants,
         dataset_types=dataset_types,
@@ -56,7 +53,6 @@ def test_construct_cohort(tmp_path):
         jobs=2,
     )
     construct_cohort(
-        datasets=datasets,
         output_dir=output_dir,
         sourcedata_dir=sourcedata,
         participants=participants,
@@ -65,7 +61,6 @@ def test_construct_cohort(tmp_path):
         space="not_used_for_raw",
     )
     construct_cohort(
-        datasets=datasets,
         output_dir=output_dir,
         sourcedata_dir=sourcedata,
         participants=participants,

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -10,8 +10,6 @@ def test_parser_for_get_data():
     args = parser.parse_args(
         [
             "install",
-            "-d",
-            str(Path()),
             "-p",
             str(Path()),
             "-o",


### PR DESCRIPTION
closes #16 

For now given all the source datasets are from openneuro we can ignore the datasets listing and make assumptions about where the datasets are and from their URL should be.

If those assumptions start failing or if users want to overrides the default URL for the datasets we will then reintroduce using the dataset_listing to get the urls from there.