### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,18 @@
----
-# Documentation
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
--   package-ecosystem: github-actions
-    directory: /
-    schedule:
-        interval: monthly
-
--   package-ecosystem: gitsubmodule
-    directory: /
-    schedule:
-        interval: monthly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    actions-infrastructure:
+      patterns:
+      - actions/*
+- package-ecosystem: gitsubmodule
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    gitsubmodule-dependencies:
+      patterns:
+      - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,19 @@
+---
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: monthly
-  groups:
-    actions-infrastructure:
-      patterns:
-      - actions/*
-- package-ecosystem: gitsubmodule
-  directory: /
-  schedule:
-    interval: monthly
-  groups:
-    gitsubmodule-dependencies:
-      patterns:
-      - '*'
+-   package-ecosystem: github-actions
+    directory: /
+    schedule:
+        interval: monthly
+    groups:
+        actions-infrastructure:
+            patterns:
+            -   actions/*
+-   package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+        interval: monthly
+    groups:
+        gitsubmodule-dependencies:
+            patterns:
+            -   '*'


### PR DESCRIPTION
Adds a `groups` section to .github/dependabot.yml so dependabot PRs are grouped per ecosystem, matching the convention applied across other repos.

## Summary by Sourcery

Build:
- Update Dependabot configuration to define grouped update rules for GitHub Actions and git submodule dependencies.